### PR TITLE
Use setuptools instead of distribute

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if sys.version_info >= (3,):
 
 setup( name='fido',
        version='1.3.0',
-       install_requires=['distribute'],
+       install_requires=['setuptools'],
        description='Format Identification for Digital Objects (FIDO)',
        packages=['fido'],
        package_data={'fido':['*.*', 'conf/*.*']},


### PR DESCRIPTION
Distribute is now [deprecated](http://pythonhosted.org/distribute/), and development has moved back upstream to setuptools. Some Linux distributions have stopped shipping compatibility layers for distribute, so the `install_requires=['distribute']` results in fido failing to import distribute at runtime.

Since fido works fine with setuptools, and `pip install distribute` just returns a compatibility shim around setuptools, I think it's safe to just specify setuptools as the dependency now.
