### PR TITLE
bad repeat interval error

### DIFF
--- a/fido/conf/formats-v81.xml
+++ b/fido/conf/formats-v81.xml
@@ -38103,7 +38103,7 @@ The creating software version number can be found at hex position 0x28-29, and t
       <pattern>
         <position>BOF</position>
         <pronom_pattern>4D2E4B2E</pronom_pattern>
-        <regex>(?s)\A.{1080,0}M\.K\.</regex>
+        <regex>(?s)\A.{1080,}M\.K\.</regex>
       </pattern>
     </signature>
     <details>
@@ -38134,7 +38134,7 @@ The creating software version number can be found at hex position 0x28-29, and t
       <pattern>
         <position>BOF</position>
         <pronom_pattern>2153637265616D211A</pronom_pattern>
-        <regex>(?s)\A.{20,0}\!Scream\!\x1a</regex>
+        <regex>(?s)\A.{20,}\!Scream\!\x1a</regex>
       </pattern>
     </signature>
     <details>
@@ -38165,7 +38165,7 @@ The creating software version number can be found at hex position 0x28-29, and t
       <pattern>
         <position>BOF</position>
         <pronom_pattern>1A100000{12}5343524D</pronom_pattern>
-        <regex>(?s)\A.{28,0}\x1a\x10\x00\x00.{12}SCRM</regex>
+        <regex>(?s)\A.{28,}\x1a\x10\x00\x00.{12}SCRM</regex>
       </pattern>
     </signature>
     <details>


### PR DESCRIPTION
With the update to pronom signature v81 some signatures now have an illegal repeat interval in the regex. The max value is lower than the min value. The pronom signatures themselves have set the maximum offset lower than the offset, so one could argue that the error is actually in Pronom. I choose to fix the signature file in Fido as that probably works faster.

The 'bad repeat interval' message is annoying as it interferes with Fido's regular output and breaks existing code that runs Fido in the background.

The proper fix would probably fix the calculate_repetition method in prepare.py, but my Python is far to rusty for me to undertake that. This patch at least gets the current code working properly again.