### PR TITLE
Regex conversion: don't attempt to create \x escapes for colons

### DIFF
--- a/fido/fido.py
+++ b/fido/fido.py
@@ -130,7 +130,7 @@ class Fido:
                 if sig[i] != "-" and sig[i] != "'" and ror:
                     seq += self.escape(sig[i])
                     continue
-                if sig[i] != "-" and sig[i] != "'" and sig[i] != " " and not ror and not byt:
+                if sig[i] != "-" and sig[i] != "'" and sig[i] != " " and sig[i] != ":" and not ror and not byt:
                     seq += "\\x" + sig[i].lower()
                     byt = True
                     continue


### PR DESCRIPTION
Refs #56 - without this, the regex converter will attempt to create a regex containing an invalid escape in the format `"\\x:"`.