### PR TITLE
get_buffers: always return same number of values; check for `length` being `None`, not falsy

### DIFF
--- a/fido/fido.py
+++ b/fido/fido.py
@@ -372,7 +372,7 @@ class Fido:
             self.current_filesize = size
             if self.current_filesize == 0:
                 sys.stderr.write("FIDO: Zero byte file (empty): Path is: {0}\n".format(filename))
-            bofbuffer, eofbuffer = self.get_buffers(f, size, seekable=True)
+            bofbuffer, eofbuffer, _ = self.get_buffers(f, size, seekable=True)
             matches = self.match_formats(bofbuffer, eofbuffer)
             container_type = self.container_type(matches)
             if container_type in ("zip", "ole"):
@@ -444,7 +444,7 @@ class Fido:
             # Consume exactly content-length bytes
             self.current_file = 'STDIN!(at ' + str(offset) + ' bytes)'
             self.current_filesize = content_length
-            bofbuffer, eofbuffer = self.get_buffers(stream, content_length)
+            bofbuffer, eofbuffer, _ = self.get_buffers(stream, content_length)
             matches = self.match_formats(bofbuffer, eofbuffer)
             # MdR: this needs attention
             if len(matches) > 0:
@@ -563,7 +563,7 @@ class Fido:
                 self.blocking_read(stream, r)
                 # and read the remaining bufsize bytes into the eofbuffer
                 eofbuffer = self.blocking_read(stream, self.bufsize)
-            return bofbuffer, eofbuffer
+            return bofbuffer, eofbuffer, bytes_to_read
 
     def walk_zip(self, filename, fileobj=None):
         """
@@ -584,7 +584,7 @@ class Fido:
                         self.current_filesize = item.file_size
                         if self.current_filesize == 0:
                             sys.stderr.write("FIDO: Zero byte file (empty): Path is: {0}\n".format(item_name))
-                        bofbuffer, eofbuffer = self.get_buffers(f, item.file_size)
+                        bofbuffer, eofbuffer, _ = self.get_buffers(f, item.file_size)
                     matches = self.match_formats(bofbuffer, eofbuffer)
                     if len(matches) > 0 and self.current_filesize > 0:
                         self.handle_matches(item_name, matches, time.clock() - t0, "signature")
@@ -619,7 +619,7 @@ class Fido:
                         tar_item_name = filename + '!' + item.name
                         self.current_file = tar_item_name
                         self.current_filesize = item.size
-                        bofbuffer, eofbuffer = self.get_buffers(f, item.size)
+                        bofbuffer, eofbuffer, _ = self.get_buffers(f, item.size)
                         matches = self.match_formats(bofbuffer, eofbuffer)
                         self.handle_matches(tar_item_name, matches, time.clock() - t0)
                         if self.container_type(matches):

--- a/fido/fido.py
+++ b/fido/fido.py
@@ -525,10 +525,10 @@ class Fido:
         If length is None, return the length as found.
         If seekable is False, the steam does not support a seek operation.
         """
-        bytes_to_read = self.bufsize if not length else min(length, self.bufsize)
+        bytes_to_read = self.bufsize if length is None else min(length, self.bufsize)
         bofbuffer = self.blocking_read(stream, bytes_to_read)
         bytes_read = len(bofbuffer)
-        if not length:
+        if length is None:
             # A stream with unknown length; have to keep two buffers around
             prevbuffer = bofbuffer
             while True:


### PR DESCRIPTION
The return value of `get_buffers` previously branched on the parameters passed to this function. If `length` is not provided then a `bytes_read` value is returned in addition to the usual two buffers, indicating the number of bytes read from a stream of unknown size.

The first commit in this PR updates the return value. Instead of returning two or three values depending on the arguments, the method now always returns three values, with the third value being set to None if not relevant. It updates every place that calls this method to ignore the third value if it's not required.

The second value fixes a bug introduced by the PEP8 cleanup commit, 6c7f798c717a20156d91ac9d2606c4c822b1e9f3. `get_buffers` used to branch in a couple of places on `length == None`, which was changed to check `length`'s falsiness. However, if `length` is zero - as it is, for example, in a zero-byte file - then the method proceeds down a branch that previously shouldn't have been possible. The second commit restores these to `length is None` checks instead.

Fixes #71.