### PR TITLE
Remove reload & sys.setdefaultencoding

### DIFF
--- a/fido/prepare.py
+++ b/fido/prepare.py
@@ -18,12 +18,6 @@ from six.moves.urllib.request import urlopen
 from .pronomutils import get_local_pronom_versions
 
 
-# MdR: 'reload(sys)' and 'setdefaultencoding("utf-8")' needed to fix utf-8 encoding errors
-# when converting from PRONOM to FIDO format
-reload(sys)
-sys.setdefaultencoding("utf-8")
-
-
 class NS:
     """
     Helper class for XML name spaces in ElementTree.


### PR DESCRIPTION
They are discouraged usage and deprecated/removed in Python3. See http://stackoverflow.com/questions/3828723/why-should-we-not-use-sys-setdefaultencodingutf-8-in-a-py-script

Versions of pyflakes newer than 1.0.0 give an error for `reload()` since it's removed in Python3, so this should fix travis errors.