### PR TITLE
Fix crash on zero byte files with non-ascii name

### DIFF
--- a/fido/fido.py
+++ b/fido/fido.py
@@ -371,7 +371,10 @@ class Fido:
             size = os.stat(filename)[6]
             self.current_filesize = size
             if self.current_filesize == 0:
-                sys.stderr.write("FIDO: Zero byte file (empty): Path is: {0}\n".format(filename))
+                try:
+                    sys.stderr.write("FIDO: Zero byte file (empty): Path is {0}\n".format(filename))
+                except UnicodeEncodeError:
+                    sys.stderr.write(u"FIDO: Zero byte file (empty): Path is {0}\n".format(filename))
             bofbuffer, eofbuffer, _ = self.get_buffers(f, size, seekable=True)
             matches = self.match_formats(bofbuffer, eofbuffer)
             container_type = self.container_type(matches)
@@ -597,7 +600,10 @@ class Fido:
                         self.current_file = item_name
                         self.current_filesize = item.file_size
                         if self.current_filesize == 0:
-                            sys.stderr.write("FIDO: Zero byte file (empty): Path is: {0}\n".format(item_name))
+                            try:
+                                sys.stderr.write("FIDO: Zero byte file (empty): Path is {0}\n".format(item_name))
+                            except UnicodeEncodeError:
+                                sys.stderr.write(u"FIDO: Zero byte file (empty): Path is {0}\n".format(item_name))
                         bofbuffer, eofbuffer, _ = self.get_buffers(f, item.file_size)
                     matches = self.match_formats(bofbuffer, eofbuffer)
                     if len(matches) > 0 and self.current_filesize > 0:

--- a/fido/fido.py
+++ b/fido/fido.py
@@ -371,10 +371,7 @@ class Fido:
             size = os.stat(filename)[6]
             self.current_filesize = size
             if self.current_filesize == 0:
-                try:
-                    sys.stderr.write("FIDO: Zero byte file (empty): Path is {0}\n".format(filename))
-                except UnicodeEncodeError:
-                    sys.stderr.write(u"FIDO: Zero byte file (empty): Path is {0}\n".format(filename))
+                sys.stderr.write("FIDO: Zero byte file (empty): Path is: " + filename + "\n")
             bofbuffer, eofbuffer, _ = self.get_buffers(f, size, seekable=True)
             matches = self.match_formats(bofbuffer, eofbuffer)
             container_type = self.container_type(matches)
@@ -600,10 +597,7 @@ class Fido:
                         self.current_file = item_name
                         self.current_filesize = item.file_size
                         if self.current_filesize == 0:
-                            try:
-                                sys.stderr.write("FIDO: Zero byte file (empty): Path is {0}\n".format(item_name))
-                            except UnicodeEncodeError:
-                                sys.stderr.write(u"FIDO: Zero byte file (empty): Path is {0}\n".format(item_name))
+                            sys.stderr.write("FIDO: Zero byte file (empty): Path is: " + item_name + "\n")
                         bofbuffer, eofbuffer, _ = self.get_buffers(f, item.file_size)
                     matches = self.match_formats(bofbuffer, eofbuffer)
                     if len(matches) > 0 and self.current_filesize > 0:

--- a/fido/prepare.py
+++ b/fido/prepare.py
@@ -344,6 +344,7 @@ def doByte(chars, i, littleendian):
         val = chr(c1 + 16 * c2)
     return (escape(val), 2)
 
+
 # \a\b\n\r\t\v
 # MdR: took out '<' and '>' out of _ordinary because they were converted to entities &lt;&gt;
 # MdR: moved '!' from _ordinary to _special because it means "NOT" in the regex world. At this time no regex in any sig has a negate set, did this to be on the safe side

--- a/fido/prepare.py
+++ b/fido/prepare.py
@@ -344,7 +344,6 @@ def doByte(chars, i, littleendian):
         val = chr(c1 + 16 * c2)
     return (escape(val), 2)
 
-
 # \a\b\n\r\t\v
 # MdR: took out '<' and '>' out of _ordinary because they were converted to entities &lt;&gt;
 # MdR: moved '!' from _ordinary to _special because it means "NOT" in the regex world. At this time no regex in any sig has a negate set, did this to be on the safe side


### PR DESCRIPTION
When an empty file with non-ascii characters in its name is processed, there is an UnicodeEncodeError raised when writing the error message. This pull request fixes that by using a unicode string for the message when needed.