### PR TITLE
Fix constructing URL resources

### DIFF
--- a/fido/prepare.py
+++ b/fido/prepare.py
@@ -14,6 +14,7 @@ import zipfile
 
 from six.moves import cStringIO
 from six.moves.urllib.request import urlopen
+from six.moves.urllib.parse import urlparse
 
 from .pronomutils import get_local_pronom_versions
 
@@ -272,7 +273,11 @@ class FormatInfo:
             for id in x.findall(TNA('ReferenceFileIdentifier')):
                 type = get_text_tna(id, 'IdentifierType')
                 if type == 'URL':
-                    url = "http://" + get_text_tna(id, 'Identifier')
+                    # Starting with PRONOM 89, some URLs contain http://
+                    # and others do not.
+                    url = get_text_tna(id, 'Identifier')
+                    if not urlparse(url).scheme:
+                        url = "http://" + url
                     ET.SubElement(rf, 'dc:identifier').text = url
                     # And calculate the checksum of this resource:
                     m = hashlib.md5()


### PR DESCRIPTION
Prior to PRONOM 89, URLs were missing the scheme; there is now a mixture of fully-qualified URLs and URLs without schemes. Treating them naively caused the fetching in `prepare` to fail.

Noticed this when trying to test #99 - downloading and converting PRONOM 89 fails without this PR.