### PR TITLE
update_signatures.py: add CLI options, new debug option

### DIFF
--- a/fido/prepare.py
+++ b/fido/prepare.py
@@ -604,23 +604,33 @@ def convert_to_regex(chars, endianness='', pos='BOF', offset='0', maxoffset=''):
     return val
 
 
-def main(args=None):
+def run(input=None, output=None, puid=None):
     """Convert PRONOM formats into FIDO signatures."""
+    versions = get_local_pronom_versions()
+
+    if input is None:
+        input = versions.get_zip_file()
+    if output is None:
+        output = versions.get_signature_file()
+
+    info = FormatInfo(input)
+    info.load_pronom_xml(puid)
+    info.save(output)
+    print('Converted {0} PRONOM formats to FIDO signatures'.format(len(info.formats)), file=sys.stderr)
+
+
+def main(args=None):
+    """Main CLI entrypoint."""
     if args is None:
         args = sys.argv[1:]
 
-    versions = get_local_pronom_versions()
-
     parser = ArgumentParser(description='Produce the FIDO format XML that is loaded at run-time')
-    parser.add_argument('-input', default=versions.get_zip_file(), help='Input file, a Zip containing PRONOM XML files')
-    parser.add_argument('-output', default=versions.get_signature_file(), help='Ouptut file')
+    parser.add_argument('-input', default=None, help='Input file, a Zip containing PRONOM XML files')
+    parser.add_argument('-output', default=None, help='Ouptut file')
     parser.add_argument('-puid', default=None, help='A particular PUID record to extract')
     args = parser.parse_args(args)
 
-    info = FormatInfo(args.input)
-    info.load_pronom_xml(args.puid)
-    info.save(args.output)
-    print('Converted {0} PRONOM formats to FIDO signatures'.format(len(info.formats)), file=sys.stderr)
+    run(input=args.input, output=args.output, puid=args.puid)
 
 
 if __name__ == '__main__':

--- a/fido/update_signatures.py
+++ b/fido/update_signatures.py
@@ -15,6 +15,7 @@ PRONOM is available from http://www.nationalarchives.gov.uk/pronom/.
 
 from __future__ import print_function
 
+from argparse import ArgumentParser
 import os
 from shutil import rmtree
 import sys
@@ -30,17 +31,20 @@ from .pronomutils import check_well_formedness, get_local_pronom_versions, get_p
 
 
 defaults = {
-    'tmp_dir': os.path.join(CONFIG_DIR, 'tmp'),
     'signatureFileName': 'DROID_SignatureFile-v{0}.xml',
     'pronomZipFileName': 'pronom-xml-v{0}.zip',
     'fidoSignatureVersion': 'format_extensions.xml',
-    'http_throttle': 0.5,  # in secs, to prevent DoS of PRONOM server
     'containerVersion': 'container-signature-20160121.xml',  # container version is frozen and needs human attention before updating,
+}
+
+options = {
+    'http_throttle': 0.5,  # in secs, to prevent DoS of PRONOM server
+    'tmp_dir': os.path.join(CONFIG_DIR, 'tmp'),
     'deleteTempDirectory': True,
 }
 
 
-def main(defaults=defaults):
+def run(defaults=defaults):
     """
     Update PRONOM signatures.
 
@@ -162,5 +166,18 @@ def main(defaults=defaults):
         sys.exit('Aborting update...')
 
 
+def main():
+    """Main CLI entrypoint."""
+    parser = ArgumentParser(description='Download and convert the latest PRONOM signatures')
+    parser.add_argument('-tmpdir', default=options['tmp_dir'], help='Location to store temporary files', dest='tmp_dir')
+    parser.add_argument('-keep_tmp', default=options['deleteTempDirectory'], help='Do not delete temporary files after completion', dest='deleteTempDirectory', action='store_false')
+    parser.add_argument('-http_throttle', default=options['http_throttle'], help='Time (in seconds) to wait between downloads', type=float, dest='http_throttle')
+    args = parser.parse_args()
+    opts = defaults.copy()
+    opts.update(vars(args))
+
+    run(opts)
+
+
 if __name__ == '__main__':
-    main(defaults)
+    main()

--- a/fido/update_signatures.py
+++ b/fido/update_signatures.py
@@ -26,7 +26,7 @@ import zipfile
 from six.moves.urllib.request import urlopen
 
 from . import __version__, CONFIG_DIR, query_yes_no
-from .prepare import main as prepare_pronom_to_fido
+from .prepare import run as prepare_pronom_to_fido
 from .pronomutils import check_well_formedness, get_local_pronom_versions, get_pronom_signature
 
 

--- a/fido/update_signatures.py
+++ b/fido/update_signatures.py
@@ -35,7 +35,8 @@ defaults = {
     'pronomZipFileName': 'pronom-xml-v{0}.zip',
     'fidoSignatureVersion': 'format_extensions.xml',
     'http_throttle': 0.5,  # in secs, to prevent DoS of PRONOM server
-    'containerVersion': 'container-signature-20160121.xml',  # container version is frozen and needs human attention before updating
+    'containerVersion': 'container-signature-20160121.xml',  # container version is frozen and needs human attention before updating,
+    'deleteTempDirectory': True,
 }
 
 
@@ -135,11 +136,13 @@ def main(defaults=defaults):
             filename = os.path.join(tmpdir, puidFileName)
             if os.path.isfile(filename):
                 zf.write(filename, arcname=puidFileName, compress_type=compression)
-                os.unlink(filename)
+                if defaults['deleteTempDirectory']:
+                    os.unlink(filename)
         zf.close()
 
-        print("Deleting temporary folder and files...")
-        rmtree(tmpdir, ignore_errors=True)
+        if defaults['deleteTempDirectory']:
+            print("Deleting temporary folder and files...")
+            rmtree(tmpdir, ignore_errors=True)
 
         print('Updating versions.xml...')
         versions = get_local_pronom_versions()


### PR DESCRIPTION
For debugging, I find it really useful to be able to control several of the defaults used by `update_signatures`. I also find it really useful to be able to disable deleting the temporary directory. I was debugging a bug that happens between downloading files and running the steps in the `prepare` module, which also happens to be where the temp files get deleted - a lesson I learned the hard way!