### PR TITLE
Update default format file to formats-v90.xml

### DIFF
--- a/fido/fido.py
+++ b/fido/fido.py
@@ -35,7 +35,7 @@ defaults = {
     'printmatch': "OK,%(info.time)s,%(info.puid)s,\"%(info.formatname)s\",\"%(info.signaturename)s\",%(info.filesize)s,\"%(info.filename)s\",\"%(info.mimetype)s\",\"%(info.matchtype)s\"\n",
     'printnomatch': "KO,%(info.time)s,,,,%(info.filesize)s,\"%(info.filename)s\",,\"%(info.matchtype)s\"\n",
     'format_files': [
-        'formats-v88.xml',
+        'formats-v90.xml',
         'format_extensions.xml'
     ],
     'containersignature_file': 'container-signature-20170330.xml',


### PR DESCRIPTION
In 1.3.6 the default format file is formats-v88.xml but the package ships with formats-v90.xml. This PR fixes that by changing the default format file to instead point to formats-v90.xml.


Resolves #111 