### PR TITLE
Resolve lint error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /.cache
 /.eggs
 .coverage
+.env/
 
 /fmtinfo.csv
 /exp

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - "python setup.py install"
 
 script:
-  - "flake8 --ignore=E501 ./fido"
+  - "flake8 ./fido"
   # pep257: fido.py is WIP
   - 'pep257 --match="(?!fido).*\.py" ./fido'
   - "pytest --cov=fido"

--- a/fido/fido.py
+++ b/fido/fido.py
@@ -477,7 +477,7 @@ class Fido:
             if (os.name != "nt"):
                 try:
                     self.current_file = os.readlink("/proc/self/fd/0")
-                except:
+                except OSError:
                     if filename is not None:
                         self.current_file = filename
                     else:

--- a/fido/update_signatures.py
+++ b/fido/update_signatures.py
@@ -94,7 +94,7 @@ def run(defaults=defaults):
             print("Creating temporary folder for download:", tmpdir)
             try:
                 os.mkdir(tmpdir)
-            except:
+            except OSError:
                 pass
         if not os.path.isdir(tmpdir):
             print("Failed to create temporary folder for PUID's, using", tmpdir)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [aliases]
 test=pytest
+
+[flake8]
+ignore = E501


### PR DESCRIPTION
flake8 3.5.0 [started using checks for bare excepts and ambiguous identifier](https://gitlab.com/pycqa/flake8/issues/361). This caused two new errors to be reported which breaks our Travis CI builds, e.g. in [build #189](https://travis-ci.org/openpreserve/fido/builds/293926164):

```
./fido/update_signatures.py:97:13: E722 do not use bare except'
./fido/fido.py:480:17: E722 do not use bare except'
```

This PR ignores both warnings in 378174d so the logic doesn't need to change.

Also in this PR:
- Added `.env/` to `.gitignore`
- Move flake8 config to `setup.cfg`