### PR TITLE
Improve performance of Python regexes with high-order repetitions

### DIFF
--- a/fido/conf/formats-v93.xml
+++ b/fido/conf/formats-v93.xml
@@ -13036,7 +13036,7 @@ Version 2.0 is the same file format as version 97</dc:description>
       <pattern>
         <position>EOF</position>
         <pronom_pattern>FFD9</pronom_pattern>
-        <regex>(?s)\xff\xd9.{0,65535}.{0,1}\Z</regex>
+        <regex>(?s)\xff\xd9.{0,65536}\Z</regex>
       </pattern>
     </signature>
     <details>
@@ -13077,7 +13077,7 @@ Version 2.0 is the same file format as version 97</dc:description>
       <pattern>
         <position>EOF</position>
         <pronom_pattern>FFD9</pronom_pattern>
-        <regex>(?s)\xff\xd9.{0,65535}.{0,1}\Z</regex>
+        <regex>(?s)\xff\xd9.{0,65536}\Z</regex>
       </pattern>
     </signature>
     <details>
@@ -13118,7 +13118,7 @@ Version 2.0 is the same file format as version 97</dc:description>
       <pattern>
         <position>EOF</position>
         <pronom_pattern>FFD9</pronom_pattern>
-        <regex>(?s)\xff\xd9.{0,65535}.{0,1}\Z</regex>
+        <regex>(?s)\xff\xd9.{0,65536}\Z</regex>
       </pattern>
     </signature>
     <details>
@@ -13167,7 +13167,7 @@ Version 2.0 is the same file format as version 97</dc:description>
       <pattern>
         <position>EOF</position>
         <pronom_pattern>FFD9</pronom_pattern>
-        <regex>(?s)\xff\xd9.{0,65535}.{0,1}\Z</regex>
+        <regex>(?s)\xff\xd9.{0,65536}\Z</regex>
       </pattern>
     </signature>
     <signature>
@@ -13259,7 +13259,7 @@ EOF: EOI marker (FF|D9) with a large offset due to the amount of photoshop metad
       <pattern>
         <position>EOF</position>
         <pronom_pattern>900000070000000430323230</pronom_pattern>
-        <regex>(?s)\x90\x00\x00\x07\x00\x00\x00\x040220.{0,65535}.{0,65535}.{0,2}\Z</regex>
+        <regex>(?s)\x90\x00\x00\x07\x00\x00\x00\x040220.{0,131072}\Z</regex>
       </pattern>
     </signature>
     <signature>
@@ -13273,7 +13273,7 @@ EOF: EOI marker (FF|D9) with a large offset due to the amount of photoshop metad
       <pattern>
         <position>EOF</position>
         <pronom_pattern>009007000400000030323230</pronom_pattern>
-        <regex>(?s)\x00\x90\x07\x00\x04\x00\x00\x000220.{0,65535}.{0,65535}.{0,2}\Z</regex>
+        <regex>(?s)\x00\x90\x07\x00\x04\x00\x00\x000220.{0,131072}\Z</regex>
       </pattern>
     </signature>
     <signature>
@@ -13287,7 +13287,7 @@ EOF: EOI marker (FF|D9) with a large offset due to the amount of photoshop metad
       <pattern>
         <position>BOF</position>
         <pronom_pattern>900000070000000430323230</pronom_pattern>
-        <regex>(?s)\A.{10,65535}.{0,65535}.{0,2}\x90\x00\x00\x07\x00\x00\x00\x040220</regex>
+        <regex>(?s)\A.{10,131072}\x90\x00\x00\x07\x00\x00\x00\x040220</regex>
       </pattern>
     </signature>
     <signature>
@@ -13301,7 +13301,7 @@ EOF: EOI marker (FF|D9) with a large offset due to the amount of photoshop metad
       <pattern>
         <position>BOF</position>
         <pronom_pattern>009007000400000030323230</pronom_pattern>
-        <regex>(?s)\A.{10,65535}.{0,65535}.{0,2}\x00\x90\x07\x00\x04\x00\x00\x000220</regex>
+        <regex>(?s)\A.{10,131072}\x00\x90\x07\x00\x04\x00\x00\x000220</regex>
       </pattern>
     </signature>
     <details>
@@ -13553,7 +13553,7 @@ EOF: EOI marker (FF|D9) with a large offset due to the amount of photoshop metad
       <pattern>
         <position>EOF</position>
         <pronom_pattern>FFD9</pronom_pattern>
-        <regex>(?s)\xff\xd9.{0,65535}.{0,65535}.{0,2}\Z</regex>
+        <regex>(?s)\xff\xd9.{0,131072}\Z</regex>
       </pattern>
     </signature>
     <signature>
@@ -13567,7 +13567,7 @@ EOF: EOI marker (FF|D9) with a large offset due to the amount of photoshop metad
       <pattern>
         <position>EOF</position>
         <pronom_pattern>FFD9</pronom_pattern>
-        <regex>(?s)\xff\xd9.{0,65535}.{0,65535}.{0,2}\Z</regex>
+        <regex>(?s)\xff\xd9.{0,131072}\Z</regex>
       </pattern>
     </signature>
     <details>
@@ -16669,7 +16669,7 @@ http://www.openoffice.org/xml/xml_specification.pdf</dc:description>
       <pattern>
         <position>EOF</position>
         <pronom_pattern>FFD9</pronom_pattern>
-        <regex>(?s)\xff\xd9.{0,65535}.{0,1}\Z</regex>
+        <regex>(?s)\xff\xd9.{0,65536}\Z</regex>
       </pattern>
     </signature>
     <signature>
@@ -24986,7 +24986,7 @@ DATA: VERSION:160 SECURITY: ENCODING: CHARSET: COMPRESSION: OLDFILEUID: NEWFILEU
       <pattern>
         <position>BOF</position>
         <pronom_pattern>786D6C6E733D22687474703A2F2F7777772E786D6C2D636D6C2E6F72672F736368656D6122</pronom_pattern>
-        <regex>(?s)\A.{0,65535}.{0,1}xmlns="http://www\.xml-cml\.org/schema"</regex>
+        <regex>(?s)\A.{0,65536}xmlns="http://www\.xml-cml\.org/schema"</regex>
       </pattern>
     </signature>
     <details>
@@ -25017,7 +25017,7 @@ DATA: VERSION:160 SECURITY: ENCODING: CHARSET: COMPRESSION: OLDFILEUID: NEWFILEU
       <pattern>
         <position>BOF</position>
         <pronom_pattern>205F61746F6D5F747970655F736361745F64697370657273696F6E5F7265616C</pronom_pattern>
-        <regex>(?s)\A.{0,65535}.{0,1} _atom_type_scat_dispersion_real</regex>
+        <regex>(?s)\A.{0,65536} _atom_type_scat_dispersion_real</regex>
       </pattern>
     </signature>
     <details>
@@ -33681,7 +33681,7 @@ The EBML specifications are work-in-progress, and can be found here: https://git
         <dc:identifier>http://www.matroska.org/downloads/test_w1.html</dc:identifier>
         <dcterms:license />
         <dc:rights />
-        <checksum type="md5">2ab1f10ce69a16e9a0081f58d537eefc</checksum>
+        <checksum type="md5">403e4814135b1f72b84570c20a050408</checksum>
       </example_file>
       <record_metadata>
         <status>unknown</status>
@@ -35996,7 +35996,7 @@ http://msdn.microsoft.com/en-us/library/dd951288(v=office.12).aspx</dc:descripti
       <pattern>
         <position>EOF</position>
         <pronom_pattern>FFD9</pronom_pattern>
-        <regex>(?s)\xff\xd9.{0,65535}.{0,1}\Z</regex>
+        <regex>(?s)\xff\xd9.{0,65536}\Z</regex>
       </pattern>
     </signature>
     <signature>
@@ -36010,7 +36010,7 @@ http://msdn.microsoft.com/en-us/library/dd951288(v=office.12).aspx</dc:descripti
       <pattern>
         <position>EOF</position>
         <pronom_pattern>FFD9</pronom_pattern>
-        <regex>(?s)\xff\xd9.{0,65535}.{0,1}\Z</regex>
+        <regex>(?s)\xff\xd9.{0,65536}\Z</regex>
       </pattern>
     </signature>
     <details>

--- a/fido/conf/versions.xml
+++ b/fido/conf/versions.xml
@@ -4,5 +4,5 @@
 	<pronomSignature>formats-v93.xml</pronomSignature>
 	<pronomContainerSignature>container-signature-20180417.xml</pronomContainerSignature>
 	<fidoExtensionSignature>format_extensions.xml</fidoExtensionSignature>
-	<updateScript>1.3.6</updateScript>
+	<updateScript>1.3.8</updateScript>
 </versions>

--- a/fido/prepare.py
+++ b/fido/prepare.py
@@ -378,21 +378,30 @@ def escape(string):
     return ''.join(c if c in _ordinary else _escape_char(c) for c in string)
 
 
+# Python now allows regex repetitions to be max out somewhere between 4 and 4.3
+# billion, cf. https://bugs.python.org/issue13169#msg180499
+MAX_REGEX_REPS = 4e9
+
+
 def calculate_repetition(char, pos, offset, maxoffset):
-    """Recursively calculates offset/maxoffset repetition, when one or both offsets is greater than 65535 bytes (64KB). See: https://bugs.python.org/issue13169."""
+    """Recursively calculates offset/maxoffset repetition, when one or both
+    offsets is greater than MAX_REGEX_REPS bytes (4GB). See:
+    https://bugs.python.org/issue13169.
+    """
+
     calcbuf = cStringIO()
 
     calcremain = False
     offsetremain = 0
     maxoffsetremain = 0
 
-    if offset is not None and int(offset) > 65535:
-        offsetremain = str(int(offset) - 65535)
-        offset = '65535'
+    if offset is not None and int(offset) > MAX_REGEX_REPS:
+        offsetremain = str(int(offset) - MAX_REGEX_REPS)
+        offset = str(int(MAX_REGEX_REPS))
         calcremain = True
-    if maxoffset is not None and int(maxoffset) > 65535:
-        maxoffsetremain = str(int(maxoffset) - 65535)
-        maxoffset = '65535'
+    if maxoffset is not None and int(maxoffset) > MAX_REGEX_REPS:
+        maxoffsetremain = str(int(maxoffset) - MAX_REGEX_REPS)
+        maxoffset = str(int(MAX_REGEX_REPS))
         calcremain = True
 
     if pos == "BOF" or pos == "EOF":

--- a/fido/prepare.py
+++ b/fido/prepare.py
@@ -384,11 +384,11 @@ MAX_REGEX_REPS = 4e9
 
 
 def calculate_repetition(char, pos, offset, maxoffset):
-    """Recursively calculates offset/maxoffset repetition, when one or both
-    offsets is greater than MAX_REGEX_REPS bytes (4GB). See:
-    https://bugs.python.org/issue13169.
-    """
+    """Recursively calculates offset/maxoffset repetition.
 
+    This function only has an effect when one or both offsets is greater than
+    MAX_REGEX_REPS bytes (4GB). See: https://bugs.python.org/issue13169.
+    """
     calcbuf = cStringIO()
 
     calcremain = False


### PR DESCRIPTION
Increases the maximum allowed number of repetitions in a constructed Python regex from 65,535 to 4e9 in accordance with https://bugs.python.org/issue13169#msg180499

Fixes #112 

    $ fido ~/Documents/Artefactual/Projects/Fido/skel_df.tif 
    FIDO v1.3.8 (formats-v93.xml, container-signature-20180417.xml, format_extensions.xml)
    OK,212,fmt/353,"Tagged Image File Format","TIFF generic (big-endian)",540134,"/Users/joeldunham/Documents/Artefactual/Projects/Fido/skel_df.tif","image/tiff","signature"
    FIDO: Processed      1 files in 302.85 msec,  3 files/sec

**Note: requires https://github.com/openpreserve/fido/pull/122 to be merged first.**