### PR TITLE
Catch exception when using -(no)matchprintf in python 3

### DIFF
--- a/fido/fido.py
+++ b/fido/fido.py
@@ -744,6 +744,8 @@ def list_files(roots, recurse=False):
 
 
 def main(args=None):
+    import ast
+
     if not args:
         args = sys.argv[1:]
 
@@ -797,12 +799,14 @@ def main(args=None):
         try:
             args.matchprintf = args.matchprintf.decode('string_escape')
         except AttributeError:
-            args.matchprintf = bytes(args.matchprintf, "utf-8").decode('unicode_escape')  # python 3
+            args.matchprintf = args.matchprintf.replace(r"\n", "\n")
+            args.matchprintf = args.matchprintf.replace(r"\t", "\t")
     if args.nomatchprintf:
         try:
             args.nomatchprintf = args.nomatchprintf.decode('string_escape')
         except AttributeError:
-            args.nomatchprintf = bytes(args.nomatchprintf, "utf-8").decode('unicode_escape')  # python 3
+            args.matchprintf = args.matchprintf.replace(r"\n", "\n")
+            args.matchprintf = args.matchprintf.replace(r"\t", "\t")
 
     fido = Fido(
         quiet=args.q,

--- a/fido/fido.py
+++ b/fido/fido.py
@@ -744,8 +744,6 @@ def list_files(roots, recurse=False):
 
 
 def main(args=None):
-    import ast
-
     if not args:
         args = sys.argv[1:]
 

--- a/fido/fido.py
+++ b/fido/fido.py
@@ -794,9 +794,15 @@ def main(args=None):
         sys.exit(0)
 
     if args.matchprintf:
-        args.matchprintf = args.matchprintf.decode('string_escape')
+        try:
+            args.matchprintf = args.matchprintf.decode('string_escape')
+        except AttributeError:
+            args.matchprintf = bytes(args.matchprintf, "utf-8").decode('unicode_escape')  # python 3
     if args.nomatchprintf:
-        args.nomatchprintf = args.nomatchprintf.decode('string_escape')
+        try:
+            args.nomatchprintf = args.nomatchprintf.decode('string_escape')
+        except AttributeError:
+            args.nomatchprintf = bytes(args.nomatchprintf, "utf-8").decode('unicode_escape')  # python 3
 
     fido = Fido(
         quiet=args.q,


### PR DESCRIPTION
String escaping was done using decode("string_escape"), which
no longer exists in python 3. Wrapped the line in a "try" and
provided a python 3 alternative in case of an AttributeError.