### PR TITLE
setup: relax six dependency constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def find_version(*file_paths):
 install_requires = [
     'olefile >= 0.4, < 1',
     'setuptools',
-    'six == 1.10.0',
+    'six >= 1.10.0, < 2',
 ]
 
 


### PR DESCRIPTION
Lower bound: the version we know it works for us. Upper bound is v2 assuming
that would be the release where backward-incompatible changes would be
introduced.

This closes #140.