### PR TITLE
Update default format file to formats-v94.xml

### DIFF
--- a/fido/fido.py
+++ b/fido/fido.py
@@ -34,7 +34,7 @@ defaults = {
     'printmatch': "OK,%(info.time)s,%(info.puid)s,\"%(info.formatname)s\",\"%(info.signaturename)s\",%(info.filesize)s,\"%(info.filename)s\",\"%(info.mimetype)s\",\"%(info.matchtype)s\"\n",
     'printnomatch': "KO,%(info.time)s,,,,%(info.filesize)s,\"%(info.filename)s\",,\"%(info.matchtype)s\"\n",
     'format_files': [
-        'formats-v93.xml',
+        'formats-v94.xml',
         'format_extensions.xml'
     ],
     'containersignature_file': 'container-signature-20180920.xml',


### PR DESCRIPTION
Much like in #111, the default `format_files` currently points to a non-existing file. This fixes it.

Maybe a test is needed to prevent this from happening again 😉 