### PR TITLE
Fixed name of `six.moves.http_client` class

### DIFF
--- a/fido/pronomutils.py
+++ b/fido/pronomutils.py
@@ -72,7 +72,7 @@ def get_pronom_signature(type_):
         else:
             sys.stderr.write("get_pronom_signature(): unknown type: " + type_)
             return False
-        webservice = http_client.HTTP("www.nationalarchives.gov.uk")
+        webservice = http_client.HTTPClient("www.nationalarchives.gov.uk")
         webservice.putrequest("POST", "/pronom/service.asmx")
         webservice.putheader("Host", "www.nationalarchives.gov.uk")
         webservice.putheader("User-Agent", "PRONOM UTILS v{0} (OPF)".format(__version__))


### PR DESCRIPTION
Existent code in `get_pronom_signature(…)` was attempting to instantiate a class `HTTP` from `six.moves.http_client` (aliased to either `httplib` or `http.client`, depending on whether your Python major version is 2 or 3) which that doesn’t exist… The correct class name, in the case of my system Python (2.7.6), my Homebrew-installed userland Python (3.7.1) and every Python version I looked at online, should be `HTTPConnection`. Changing this class name in my local installation fixed `get_pronom_signature(…)` and therefore the `fido-update-signatures` CLT.