### PR TITLE
Add status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Format Identification for Digital Objects (fido)
 
 By [Open Preservation Foundation](http://www.openpreservation.org)
 
+[![Build Status](https://travis-ci.org/openpreserve/fido.svg?branch=master)](https://travis-ci.org/openpreserve/fido) [![Code Coverage](https://codecov.io/gh/openpreserve/fido/branch/master/graph/badge.svg)](https://codecov.io/gh/openpreserve/fido)
+
 FIDO is a command-line tool to identify the file formats of digital objects.
 It is designed for simple integration into automated work-flows.
 


### PR DESCRIPTION
- Travis CI build status
- Codecov.io code coverage status

Could not add badges for Codacy because the necessary URLs are apparently only available to project administrators.