### PR TITLE
FIX - Pylint issues part one

### DIFF
--- a/fido/fido.py
+++ b/fido/fido.py
@@ -447,7 +447,7 @@ class Fido:
         elif extension and (len(matches) == 0 or self.current_filesize == 0):
             # we can only determine the filename from the STDIN stream
             # on Linux, on Windows there is not a (simple) way to do that
-            if (os.name != "nt"):
+            if os.name != "nt":
                 try:
                     self.current_file = os.readlink("/proc/self/fd/0")
                 except OSError:
@@ -470,7 +470,7 @@ class Fido:
         that we can look inside of (e.g., zip, tar).
         @return False, zip, or tar.
         """
-        for (format_, unused) in matches:
+        for (format_, _) in matches:
             container = format_.find('container')
             if container is not None:
                 return container.text
@@ -565,7 +565,7 @@ class Fido:
             with zipfile.ZipFile((fileobj if fileobj else filename), 'r') as zipstream:
                 for item in zipstream.infolist():
                     if item.file_size == 0:
-                        continue  # TODO: Find a better test for isdir
+                        continue  # TODO: Find a better test for isdir, Python 3.6 adds is_dir() test to ZipInfo class
                     t0 = time.clock()
                     with zipstream.open(item) as f:
                         item_name = filename + '!' + item.filename
@@ -624,7 +624,7 @@ class Fido:
         """
         if match_list != []:
             f1_puid = self.get_puid(f1)
-            for (f2, unused) in match_list:
+            for (f2, _) in match_list:
                 if f1 == f2:
                     continue
                 elif f1_puid in self.puid_has_priority_over_map[self.get_puid(f2)]:
@@ -736,7 +736,7 @@ def list_files(roots, recurse=False):
         if os.path.isfile(root):
             yield root
         else:
-            for path, unused, files in os.walk(root):
+            for path, _, files in os.walk(root):
                 for f in files:
                     yield os.path.join(path, f)
                 if not recurse:

--- a/fido/package.py
+++ b/fido/package.py
@@ -7,7 +7,7 @@ import olefile
 from six import iteritems
 
 
-class Package(object):
+class Package():
     """Base class for container support."""
 
     def _process_puid_map(self, data, puid_map):

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,23 @@
 #!/usr/bin/env python
+"""Setup installer for Fido."""
 # -*- coding: utf-8 -*-
 
 import codecs
 import os
 import re
-import sys
 
 from setuptools import setup
 
 
 def read(*parts):
+    """Read the contents of files in parts and return contents."""
     path = os.path.join(os.path.dirname(__file__), *parts)
     with codecs.open(path, encoding='utf-8') as fobj:
         return fobj.read()
 
 
 def find_version(*file_paths):
+    """Search contents of files in file_paths for version number."""
     version_file = read(*file_paths)
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
     if version_match:

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,7 +1,4 @@
 import os
-import zipfile
-
-import pytest
 
 from fido.package import ZipPackage
 


### PR DESCRIPTION
- removed unused `imports`;
- replaced unused variables with `_`;
- removed unnecessary brackets and use of `(object)` in class declarations; and
- added some missing DocStrings.