### PR TITLE
RC - Release candidate 1.4.0rc1

### DIFF
--- a/fido/__init__.py
+++ b/fido/__init__.py
@@ -14,7 +14,7 @@ from os.path import abspath, dirname, join
 from six.moves import input as rinput
 
 
-__version__ = '1.4'
+__version__ = '1.4.0rc1'
 
 
 CONFIG_DIR = join(abspath(dirname(__file__)), 'conf')

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,10 @@ tests_require = [
     'pytest',
 ]
 
+EXTRAS = {
+    'testing': tests_require,
+    'setup': setup_requires,
+}
 
 setup(
     name='opf-fido',
@@ -53,6 +57,7 @@ setup(
     install_requires=install_requires,
     setup_requires=setup_requires,
     tests_require=tests_require,
+    extras_require=EXTRAS,
     packages=['fido'],
     package_data={'fido': ['*.*', 'conf/*.*']},
     entry_points={'console_scripts': [

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,0 @@
-sonar.projectKey=org.opf-labs:fido
-sonar.projectName=Fido
-sonar.projectVersion=1.3
-sonar.sources=fido
-sonar.language=py
-sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
- moved to semantic versioning, e.g. `major`.`minor`.`patch`;
- added `rc1` suffix for release candidate;
- added `extras_require` entry to `setup.py`; and
- deleted redundant `sonar-project.properties`.

The `extras_require` entry allows `testing` and `setup` packges to be
installed, for example `pip install -e .[testing]` will install fido with
its `tests_require` packages also. `pip install -e .[setup]` installs the
`setup_requires` packages. `pip install -e .[testing,setup]` works as you'd
hope :).