### PR TITLE
Bigger warning for container signature update

### DIFF
--- a/fido/update_signatures.py
+++ b/fido/update_signatures.py
@@ -35,7 +35,7 @@ DEFAULTS = {
     'signatureFileName': 'DROID_SignatureFile-v{0}.xml',
     'pronomZipFileName': 'pronom-xml-v{0}.zip',
     'fidoSignatureVersion': 'format_extensions.xml',
-    'containerVersion': 'container-signature-20160121.xml',  # container version is frozen and needs human attention before updating,
+    'containerVersion': 'container-signature-UPDATE-ME.xml',  # container version is frozen and needs human attention before updating,
 }
 
 OPTIONS = {


### PR DESCRIPTION
This step can easily be missed when upgrading FIDO. This makes it more obvious!