### PR TITLE
Remove setuptools dependency

### DIFF
--- a/fido/fido.py
+++ b/fido/fido.py
@@ -251,7 +251,7 @@ class Fido:
         return format.findall('signature')
 
     def has_priority_over(self, format, possibly_inferior):
-        return self.get_puid(possibly_inferior)in self.puid_has_priority_over_map[self.get_puid(format)]
+        return self.get_puid(possibly_inferior) in self.puid_has_priority_over_map[self.get_puid(format)]
 
     def get_puid(self, format):
         return format.find('puid').text

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ def find_version(*file_paths):
 
 install_requires = [
     'olefile >= 0.4, < 1',
-    'setuptools',
     'six >= 1.10.0, < 2',
 ]
 


### PR DESCRIPTION
fido does not need setuptools to run correctly and the requirement is considered unsafe.

I don't expect this to be a breaking change but I'd be curious to hear your thoughts. I've found that pytest was also listing setuptools but they stopped doing so in pytest v4.6.0 (commit https://github.com/pytest-dev/pytest/commit/13f02af97d676bdf7143aa1834c8898fbf753d87), presumably because they were already using `setup_requires`.

Fixes #187.