### PR TITLE
Update olefile version contraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def find_version(*file_paths):
 
 
 install_requires = [
-    'olefile >= 0.4, < 1',
+    'olefile >= 0.46, < 1',
     'six >= 1.10.0, < 2',
 ]
 


### PR DESCRIPTION
This commit ensures that fido uses olefile~=0.46 which makes possible to use OleFileIO as a context manager.

It potentially fixes https://github.com/openpreserve/fido/issues/179 (confirmed locally), assuming that the user had and older release of olefile installed. That would explain the error reported, where `__enter__` seems to be missing.

```
File "/usr/local/lib/python3.6/dist-packages/opf_fido-1.4.0-py3.6.egg/fido/package.py", line 40, in detect_formats
  with olefile.OleFileIO(self.ole) as ole:
AttributeError: __enter__
```