### PR TITLE
FIX: Signature preparation niggles and bugs

### DIFF
--- a/fido/conf/fido-formats.xsd
+++ b/fido/conf/fido-formats.xsd
@@ -5,8 +5,8 @@ Usage of DC has been based on these references:
   http://dublincore.org/documents/usageguide/qualifiers.shtml
   http://www.dublincore.org/documents/dc-xml-guidelines/
 -->
-<xs:schema elementFormDefault="qualified" 
-  xmlns:xs="http://www.w3.org/2001/XMLSchema"  
+<xs:schema elementFormDefault="qualified"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:dc="http://purl.org/dc/elements/1.1/"
   xmlns:dcterms="http://purl.org/dc/terms/">
@@ -34,7 +34,7 @@ Usage of DC has been based on these references:
         <xs:element maxOccurs="unbounded" minOccurs="0" ref="extension"/>
         <xs:element maxOccurs="1" minOccurs="0" name="apple_uti" type="xs:string"/>
         <xs:element maxOccurs="unbounded" minOccurs="0" ref="has_priority_over"/>
-        <xs:element maxOccurs="unbounded" ref="signature"/>
+        <xs:element maxOccurs="unbounded"  minOccurs="0" ref="signature"/>
         <xs:element minOccurs="0" ref="note"/>
         <xs:element maxOccurs="1" ref="details"/>
       </xs:sequence>

--- a/fido/fido.py
+++ b/fido/fido.py
@@ -29,7 +29,7 @@ from six.moves import range
 
 from fido import __version__, CONFIG_DIR
 from fido.package import OlePackage, ZipPackage
-from fido.pronomutils import get_local_pronom_versions
+from fido.versions import get_local_versions
 from fido.char_handler import escape
 
 
@@ -785,7 +785,7 @@ def main(args=None):
 
     timer = PerfTimer()
 
-    versions = get_local_pronom_versions(args.confdir)
+    versions = get_local_versions(args.confdir)
 
     defaults['xml_pronomSignature'] = versions.pronom_signature
     defaults['containersignature_file'] = versions.pronom_container_signature

--- a/fido/prepare.py
+++ b/fido/prepare.py
@@ -17,7 +17,7 @@ from six.moves.urllib.request import urlopen
 from six.moves.urllib.parse import urlparse
 from six.moves.urllib.error import HTTPError
 
-from .pronomutils import get_local_pronom_versions
+from .versions import get_local_versions
 from .char_handler import escape
 
 
@@ -694,7 +694,7 @@ def convert_to_regex(chars, endianness='', pos='BOF', offset='0', maxoffset=''):
 
 def run(input=None, output=None, puid=None):
     """Convert PRONOM formats into FIDO signatures."""
-    versions = get_local_pronom_versions()
+    versions = get_local_versions()
 
     if input is None:
         input = versions.get_zip_file()

--- a/fido/pronom/http.py
+++ b/fido/pronom/http.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-FIDO: Format Identifier for Digital Objects
+FIDO: Format Identifier for Digital Objects.
 
 Copyright 2010 The Open Preservation Foundation
 

--- a/fido/pronom/http.py
+++ b/fido/pronom/http.py
@@ -19,11 +19,11 @@ limitations under the License.
 
 PRONOM format signatures HTTP calls.
 """
-import urllib.request
+from six.moves import urllib
 
 def get_sig_xml_for_puid(puid):
     """Return the full PRONOM signature XML for the passed PUID."""
     req = urllib.request.Request("http://www.nationalarchives.gov.uk/pronom/{}.xml".format(puid))
-    with urllib.request.urlopen(req) as response:
-        xml = response.read()
+    response = urllib.request.urlopen(req)
+    xml = response.read()
     return xml

--- a/fido/pronom/http.py
+++ b/fido/pronom/http.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+FIDO: Format Identifier for Digital Objects
+
+Copyright 2010 The Open Preservation Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+PRONOM format signatures HTTP calls.
+"""
+import urllib.request
+
+def get_sig_xml_for_puid(puid):
+    """Return the full PRONOM signature XML for the passed PUID."""
+    req = urllib.request.Request("http://www.nationalarchives.gov.uk/pronom/{}.xml".format(puid))
+    with urllib.request.urlopen(req) as response:
+        xml = response.read()
+    return xml

--- a/fido/pronom/http.py
+++ b/fido/pronom/http.py
@@ -21,6 +21,7 @@ PRONOM format signatures HTTP calls.
 """
 from six.moves import urllib
 
+
 def get_sig_xml_for_puid(puid):
     """Return the full PRONOM signature XML for the passed PUID."""
     req = urllib.request.Request("http://www.nationalarchives.gov.uk/pronom/{}.xml".format(puid))

--- a/fido/toxml.py
+++ b/fido/toxml.py
@@ -25,7 +25,7 @@ import csv
 import sys
 
 from . import __version__
-from .pronomutils import get_local_pronom_versions
+from .versions import get_local_versions
 
 
 def main():
@@ -35,7 +35,7 @@ def main():
     <versions>
         <fido_version>{0}</fido_version>
         <signature_version>{1}</signature_version>
-    </versions>""".format(__version__, get_local_pronom_versions().pronom_version))
+    </versions>""".format(__version__, get_local_versions().pronom_version))
 
     reader = csv.reader(sys.stdin)
 

--- a/fido/update_signatures.py
+++ b/fido/update_signatures.py
@@ -25,7 +25,7 @@ import zipfile
 
 from . import __version__, CONFIG_DIR, query_yes_no
 from .prepare import run as prepare_pronom_to_fido
-from .pronomutils import get_local_pronom_versions
+from .versions import get_local_versions
 from .pronom.soap import get_pronom_sig_version, get_pronom_signature, NS
 from .pronom.http import get_sig_xml_for_puid
 
@@ -195,7 +195,7 @@ def get_puid_file_name(format_ele):
 def update_versions_xml(defaults, currentVersion):
     """Create new versions identified sig XML file."""
     print('Updating versions.xml...')
-    versions = get_local_pronom_versions()
+    versions = get_local_versions()
     versions.pronom_version = str(currentVersion)
     versions.pronom_signature = "formats-v" + str(currentVersion) + ".xml"
     versions.pronom_container_signature = defaults['containerVersion']

--- a/fido/update_signatures.py
+++ b/fido/update_signatures.py
@@ -149,8 +149,10 @@ def download_signatures(defaults, format_eles, resume, tmpdir):
 
 def download_sig(format_ele, tmpdir, resume):
     """
-    Download an individual PRONOM signature identified from the PRONOM sig
-    file FileFormat element. The downloaded signature is written to tmpdir.
+    Download an individual PRONOM signature.
+
+    The signature to be downloaded is identified by the FileFormat element
+    parameter format_ele. The downloaded signature is written to tmpdir.
     """
     puid, puidFileName = get_puid_file_name(format_ele)
     filename = os.path.join(tmpdir, puidFileName)

--- a/fido/update_signatures.py
+++ b/fido/update_signatures.py
@@ -23,13 +23,11 @@ import time
 from xml.etree import ElementTree as CET
 import zipfile
 
-from six.moves.urllib.request import urlopen
-from six.moves.urllib.error import URLError
-
 from fido import __version__, CONFIG_DIR, query_yes_no
 from fido.prepare import run as prepare_pronom_to_fido
 from fido.pronomutils import get_local_pronom_versions
-from fido.pronom.soap import get_pronom_sig_version, get_pronom_signature
+from fido.pronom.soap import get_pronom_sig_version, get_pronom_signature, NS
+from fido.pronom.http import get_sig_xml_for_puid
 
 
 DEFAULTS = {
@@ -56,57 +54,18 @@ def run(defaults=None):
     defaults = defaults or DEFAULTS
     try:
         print("Contacting PRONOM...")
-        currentVersion = get_pronom_sig_version()
-        if not currentVersion:
-            sys.exit('Failed to obtain PRONOM signature file version number, please try again.')
-
-        print("Querying latest signaturefile version...")
-        signatureFile = os.path.join(CONFIG_DIR, defaults['signatureFileName'].format(currentVersion))
-        if os.path.isfile(signatureFile):
-            print("You already have the latest PRONOM signature file, version", currentVersion)
-            if not query_yes_no("Update anyway?"):
-                sys.exit('Aborting update...')
-
-        print("Downloading signature file version {}...".format(currentVersion))
-        currentFile, _ = get_pronom_signature()
-        if not currentFile:
-            sys.exit('Failed to obtain PRONOM signature file, please try again.')
-        print("Writing {0}...".format(defaults['signatureFileName'].format(currentVersion)))
-        with open(signatureFile, 'w') as file_:
-            file_.write(currentFile)
-
+        currentVersion, signatureFile = sig_version_check(defaults)
+        download_sig_file(defaults, currentVersion, signatureFile)
         print("Extracting PRONOM PUID's from signature file...")
         tree = CET.parse(signatureFile)
-        puids = []
-        for node in tree.iter("{http://www.nationalarchives.gov.uk/pronom/SignatureFile}FileFormat"):
-            puids.append(node.get("PUID"))
-        print("Found {} PRONOM PUID's".format(len(puids)))
-
-        print("Downloading signatures can take a while")
-        if not query_yes_no("Continue and download signatures?"):
-            sys.exit('Aborting update...')
-        tmpdir = defaults['tmp_dir']
-        resume_download = False
-        if os.path.isdir(tmpdir):
-            print("Found previously created temporary folder for download:", tmpdir)
-            resume_download = query_yes_no('Do you want to resume download (yes) or start over (no)?')
-            if resume_download:
-                print("Resuming download...")
-        else:
-            print("Creating temporary folder for download:", tmpdir)
-            try:
-                os.mkdir(tmpdir)
-            except OSError:
-                pass
-        if not os.path.isdir(tmpdir):
-            sys.stderr.write("Failed to create temporary folder for PUID's, using: " + tmpdir)
-
-        download_signatures(defaults, puids, resume_download, tmpdir)
-        create_zip_file(defaults, puids, currentVersion, tmpdir)
+        format_eles = tree.findall('.//sig:FileFormat', NS)
+        print("Found {} PRONOM FileFormat elements".format(len(format_eles)))
+        tmpdir, resume = init_sig_download(defaults)
+        download_signatures(defaults, format_eles, resume, tmpdir)
+        create_zip_file(defaults, format_eles, currentVersion, tmpdir)
         if defaults['deleteTempDirectory']:
             print("Deleting temporary folder and files...")
             rmtree(tmpdir, ignore_errors=True)
-
         update_versions_xml(defaults, currentVersion)
 
         # TODO: there should be a check here to handle prepare.main exit() signal (-1/0/1/...)
@@ -117,48 +76,87 @@ def run(defaults=None):
     except KeyboardInterrupt:
         sys.exit('Aborting update...')
 
+def sig_version_check(defaults):
+    print("Contacting PRONOM...")
+    currentVersion = get_pronom_sig_version()
+    if not currentVersion:
+        sys.exit('Failed to obtain PRONOM signature file version number, please try again.')
 
-def download_signatures(defaults, puids, resume_download, tmpdir):
+    print("Querying latest signaturefile version...")
+    signatureFile = os.path.join(CONFIG_DIR, defaults['signatureFileName'].format(currentVersion))
+    if os.path.isfile(signatureFile):
+        print("You already have the latest PRONOM signature file, version", currentVersion)
+        if not query_yes_no("Update anyway?"):
+            sys.exit('Aborting update...')
+    return currentVersion, signatureFile
+
+def download_sig_file(defaults, currentVersion, signatureFile):
+    print("Downloading signature file version {}...".format(currentVersion))
+    currentFile, _ = get_pronom_signature()
+    if not currentFile:
+        sys.exit('Failed to obtain PRONOM signature file, please try again.')
+    print("Writing {0}...".format(defaults['signatureFileName'].format(currentVersion)))
+    with open(signatureFile, 'w') as file_:
+        file_.write(currentFile)
+
+def init_sig_download(defaults):
+    print("Downloading signatures can take a while")
+    if not query_yes_no("Continue and download signatures?"):
+        sys.exit('Aborting update...')
+    tmpdir = defaults['tmp_dir']
+    resume = False
+    if os.path.isdir(tmpdir):
+        print("Found previously created temporary folder for download:", tmpdir)
+        resume = query_yes_no('Do you want to resume download (yes) or start over (no)?')
+        if resume:
+            print("Resuming download...")
+    else:
+        print("Creating temporary folder for download:", tmpdir)
+        try:
+            os.mkdir(tmpdir)
+        except OSError:
+            pass
+    if not os.path.isdir(tmpdir):
+        sys.stderr.write("Failed to create temporary folder for PUID's, using: " + tmpdir)
+    return tmpdir, resume
+
+def download_signatures(defaults, format_eles, resume, tmpdir):
     """Download PRONOM signatures and write to individual files."""
     print("Downloading signatures, one moment please...")
-    numberPuids = len(puids)
+    numberPuids = len(format_eles)
     one_percent = (float(numberPuids) / 100)
     numfiles = 0
-    for puid in puids:
-        puidType, puidNum = puid.split("/")
-        puidFileName = "puid." + puidType + "." + puidNum + ".xml"
-        filename = os.path.join(tmpdir, puidFileName)
-        if os.path.isfile(filename) and resume_download:
-            numfiles += 1
-            continue
-        puid_url = "http://www.nationalarchives.gov.uk/pronom/{}.xml".format(puid)
-        try:
-            filehandle = urlopen(puid_url)
-        except URLError as e:
-            sys.stderr.write("Failed to download signature file:" + puid_url)
-            sys.stderr.write("Error:" + str(e))
-            sys.exit('Please restart and resume download.')
-        with open(filename, 'wb') as file_:
-            for lines in filehandle.readlines():
-                file_.write(lines)
-        filehandle.close()
+    for format_ele in format_eles:
+        download_sig(format_ele, tmpdir, resume)
         numfiles += 1
         percent = int(float(numfiles) / one_percent)
         print(r"{}/{} files [{}%]".format(numfiles, numberPuids, percent))
         time.sleep(defaults['http_throttle'])
     print("100%")
 
+def download_sig(format_ele, tmpdir, resume):
+    puid, puidFileName = get_puid_file_name(format_ele)
+    filename = os.path.join(tmpdir, puidFileName)
+    if os.path.isfile(filename) and resume:
+        return
+    try:
+        xml = get_sig_xml_for_puid(puid)
+    except Exception as e:
+        sys.stderr.write("Failed to download signature file:" + puid)
+        sys.stderr.write("Error:" + str(e))
+        sys.exit('Please restart and resume download.')
+    with open(filename, 'wb') as file_:
+        file_.write(xml)
 
-def create_zip_file(defaults, puids, currentVersion, tmpdir):
+def create_zip_file(defaults, format_eles, currentVersion, tmpdir):
     """Create zip file of signatures."""
     print("Creating PRONOM zip...")
     compression = zipfile.ZIP_DEFLATED if 'zlib' in sys.modules else zipfile.ZIP_STORED
     modes = {zipfile.ZIP_DEFLATED: 'deflated', zipfile.ZIP_STORED: 'stored'}
     zf = zipfile.ZipFile(os.path.join(CONFIG_DIR, defaults['pronomZipFileName'].format(currentVersion)), mode='w')
     print("Adding files with compression mode", modes[compression])
-    for puid in puids:
-        puidType, puidNum = puid.split("/")
-        puidFileName = "puid.{}.{}.xml".format(puidType, puidNum)
+    for format_ele in format_eles:
+        _, puidFileName = get_puid_file_name(format_ele)
         filename = os.path.join(tmpdir, puidFileName)
         if os.path.isfile(filename):
             zf.write(filename, arcname=puidFileName, compress_type=compression)
@@ -166,6 +164,10 @@ def create_zip_file(defaults, puids, currentVersion, tmpdir):
                 os.unlink(filename)
     zf.close()
 
+def get_puid_file_name(format_ele):
+    puid = format_ele.get('PUID')
+    puidType, puidNum = puid.split("/")
+    return puid, 'puid.{}.{}.xml'.format(puidType, puidNum)
 
 def update_versions_xml(defaults, currentVersion):
     """Create new versions identified sig XML file."""
@@ -178,7 +180,6 @@ def update_versions_xml(defaults, currentVersion):
     versions.update_script = __version__
     versions.write()
 
-
 def main():
     """Main CLI entrypoint."""
     parser = ArgumentParser(description='Download and convert the latest PRONOM signatures')
@@ -190,7 +191,6 @@ def main():
     opts.update(vars(args))
 
     run(opts)
-
 
 if __name__ == '__main__':
     main()

--- a/fido/update_signatures.py
+++ b/fido/update_signatures.py
@@ -76,7 +76,9 @@ def run(defaults=None):
     except KeyboardInterrupt:
         sys.exit('Aborting update...')
 
+
 def sig_version_check(defaults):
+    """Return a tuple consisting of current sig file version and the derived file name."""
     print("Contacting PRONOM...")
     currentVersion = get_pronom_sig_version()
     if not currentVersion:
@@ -90,16 +92,25 @@ def sig_version_check(defaults):
             sys.exit('Aborting update...')
     return currentVersion, signatureFile
 
-def download_sig_file(defaults, currentVersion, signatureFile):
-    print("Downloading signature file version {}...".format(currentVersion))
+
+def download_sig_file(defaults, version, signatureFile):
+    """Download the latest version of the PRONOM sigs to signatureFile."""
+    print("Downloading signature file version {}...".format(version))
     currentFile, _ = get_pronom_signature()
     if not currentFile:
         sys.exit('Failed to obtain PRONOM signature file, please try again.')
-    print("Writing {0}...".format(defaults['signatureFileName'].format(currentVersion)))
+    print("Writing {0}...".format(defaults['signatureFileName'].format(version)))
     with open(signatureFile, 'w') as file_:
         file_.write(currentFile)
 
+
 def init_sig_download(defaults):
+    """
+    Initialise the download of individual PRONOM signatures.
+
+    Handles user input and resumption of interupted downloads.
+    Return a tuple of the temp directory for writing and a boolean resume flag.
+    """
     print("Downloading signatures can take a while")
     if not query_yes_no("Continue and download signatures?"):
         sys.exit('Aborting update...')
@@ -120,6 +131,7 @@ def init_sig_download(defaults):
         sys.stderr.write("Failed to create temporary folder for PUID's, using: " + tmpdir)
     return tmpdir, resume
 
+
 def download_signatures(defaults, format_eles, resume, tmpdir):
     """Download PRONOM signatures and write to individual files."""
     print("Downloading signatures, one moment please...")
@@ -134,7 +146,12 @@ def download_signatures(defaults, format_eles, resume, tmpdir):
         time.sleep(defaults['http_throttle'])
     print("100%")
 
+
 def download_sig(format_ele, tmpdir, resume):
+    """
+    Download an individual PRONOM signature identified from the PRONOM sig
+    file FileFormat element. The downloaded signature is written to tmpdir.
+    """
     puid, puidFileName = get_puid_file_name(format_ele)
     filename = os.path.join(tmpdir, puidFileName)
     if os.path.isfile(filename) and resume:
@@ -147,6 +164,7 @@ def download_sig(format_ele, tmpdir, resume):
         sys.exit('Please restart and resume download.')
     with open(filename, 'wb') as file_:
         file_.write(xml)
+
 
 def create_zip_file(defaults, format_eles, currentVersion, tmpdir):
     """Create zip file of signatures."""
@@ -164,10 +182,13 @@ def create_zip_file(defaults, format_eles, currentVersion, tmpdir):
                 os.unlink(filename)
     zf.close()
 
+
 def get_puid_file_name(format_ele):
+    """Return a tupe of PUID and PUID file name derived from format_ele."""
     puid = format_ele.get('PUID')
     puidType, puidNum = puid.split("/")
     return puid, 'puid.{}.{}.xml'.format(puidType, puidNum)
+
 
 def update_versions_xml(defaults, currentVersion):
     """Create new versions identified sig XML file."""
@@ -180,6 +201,7 @@ def update_versions_xml(defaults, currentVersion):
     versions.update_script = __version__
     versions.write()
 
+
 def main():
     """Main CLI entrypoint."""
     parser = ArgumentParser(description='Download and convert the latest PRONOM signatures')
@@ -189,7 +211,6 @@ def main():
     args = parser.parse_args()
     opts = DEFAULTS.copy()
     opts.update(vars(args))
-
     run(opts)
 
 if __name__ == '__main__':

--- a/fido/update_signatures.py
+++ b/fido/update_signatures.py
@@ -215,5 +215,6 @@ def main():
     opts.update(vars(args))
     run(opts)
 
+
 if __name__ == '__main__':
     main()

--- a/fido/versions.py
+++ b/fido/versions.py
@@ -28,11 +28,11 @@ import six
 from fido import CONFIG_DIR
 
 
-class LocalPronomVersions(object):
+class LocalVersions(object):
     """
-    Parse local PRONOM signature versions XML file.
+    Parse local versions XML file.
 
-    This is how the XML document should look like:
+    This is what the XML document should look like:
 
     <?xml version="1.0" encoding="UTF-8"?>
     <versions>
@@ -98,6 +98,6 @@ class LocalPronomVersions(object):
         self.tree.write(self.versions_file, xml_declaration=True, method='xml', encoding='utf-8')
 
 
-def get_local_pronom_versions(config_dir=CONFIG_DIR):
-    """Return an instance of LocalPronomVersions loaded with `conf/versions.xml`."""
-    return LocalPronomVersions(os.path.join(config_dir, 'versions.xml'))
+def get_local_versions(config_dir=CONFIG_DIR):
+    """Return an instance of LocalVersions loaded with `conf/versions.xml`."""
+    return LocalVersions(os.path.join(config_dir, 'versions.xml'))


### PR DESCRIPTION
- refactored `./fido/update_signatures.py` to add clarity;
- generated FIDO sig file now validates against `fido/config/fido-formats.xsd`
  + fixed inconsistency between FIDO sig schema and 'fido/prepare.py''s use of 'apple_uid' and `apple_uti`;
- PRONOM HTTP methods in dedicated `./fido/pronom/http.py` module (this needs to get more methods or merging with the SOAP module);
- added basic (hacky) catch for 404s when downloading test resources;
- safer use of empty list default for `fido/prepare.py FormatInfo:__init__`.