### PR TITLE
Add Unicode support in Windows and Python 2.7

### DIFF
--- a/fido/fido.py
+++ b/fido/fido.py
@@ -13,6 +13,7 @@ from __future__ import absolute_import
 from argparse import ArgumentParser, RawTextHelpFormatter
 from contextlib import closing
 import os
+import platform
 import re
 import sys
 import tarfile
@@ -25,6 +26,7 @@ except ImportError:
 from xml.etree import cElementTree as ET
 import zipfile
 
+from six import PY2
 from six.moves import range
 
 from fido import __version__, CONFIG_DIR
@@ -751,7 +753,16 @@ def list_files(roots, recurse=False):
                     break
 
 
+def set_up_platform():
+    """Enable Unicode display when running Python from Windows console."""
+    if platform.system() == 'Windows' and PY2:
+        import win_unicode_console  # noqa: E402
+        win_unicode_console.enable(use_unicode_argv=True)
+
+
 def main(args=None):
+    set_up_platform()
+
     if not args:
         args = sys.argv[1:]
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ def find_version(*file_paths):
 install_requires = [
     'olefile >= 0.46, < 1',
     'six >= 1.10.0, < 2',
+    'win-unicode-console >= 0.5; python_version == "2.7" and platform_system == "Windows"',
 ]
 
 


### PR DESCRIPTION
This pull request enables Unicode support when running Python 2.7 from the Windows console. It relies on the [win-unicode-console](https://github.com/Drekin/win-unicode-console) package which monkeypatches the standard library when `platform.system() == 'Windows' and six.PY2`. It can be reverted once fido abandons Python 2.7 (EOL reached) since 3.6+ is perfectly capable.

Fixes https://github.com/openpreserve/fido/issues/100.

![image](https://user-images.githubusercontent.com/606459/114416994-83f01c80-9bb1-11eb-81b1-6ba57fa4033b.png)
