### PR TITLE
fido: correct container version

### DIFF
--- a/fido/fido.py
+++ b/fido/fido.py
@@ -42,7 +42,7 @@ defaults = {
         'formats-v96.xml',
         'format_extensions.xml'
     ],
-    'containersignature_file': 'container-signature-20180920.xml',
+    'containersignature_file': 'container-signature-20200121.xml',
     'container_bufsize': 512 * 1024,  # (bytes)
     'description': """Format Identification for Digital Objects (fido).
 FIDO is a command-line tool to identify the file formats of digital objects.


### PR DESCRIPTION
This isn't a major mistake - I don't believe this default is actually used. But we don't ship a file with this name anymore.