### PR TITLE
Change default formats-v104.xml to formats-109.xml which is the default format

### DIFF
--- a/fido/fido.py
+++ b/fido/fido.py
@@ -41,7 +41,7 @@ defaults = {
     'printmatch': "OK,%(info.time)s,%(info.puid)s,\"%(info.formatname)s\",\"%(info.signaturename)s\",%(info.filesize)s,\"%(info.filename)s\",\"%(info.mimetype)s\",\"%(info.matchtype)s\"\n",
     'printnomatch': "KO,%(info.time)s,,,,%(info.filesize)s,\"%(info.filename)s\",,\"%(info.matchtype)s\"\n",
     'format_files': [
-        'formats-v104.xml',
+        'formats-v109.xml',
         'format_extensions.xml'
     ],
     'containersignature_file': 'container-signature-20200121.xml',


### PR DESCRIPTION
#213 corrected:
"FileNotFoundError: [Errno 2] No such file or directory: '.../fido/conf/formats-v104.xml"
Change default formats-v104.xml to formats-109.xml which is the default format