### PR TITLE
chore(ci): update upload/download-artifact

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -36,7 +36,7 @@ jobs:
         run: coverage xml -o cobertura.xml
       - name: Upload coverage report
         if: matrix.python-version == 3.10
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: cobertura.xml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Download coverage report
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coverage-report
           path: cobertura.xml


### PR DESCRIPTION
These have to be updated in lockstep; v3 and v4 artifacts are incompatible with each other.

Closes #222.